### PR TITLE
fix setup-dev-data.sh

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -1,16 +1,18 @@
 services:
   flaskdebugrun:
     image: tomgobravo/tourist-with-flask:tourist-docker
-    working_dir: /app
+    working_dir: /workspace/tourist-with-flask
     command: flask --debug run
     environment:
-      PYTHONPATH: "/app"
+      PYTHONPATH: "/workspace/tourist-with-flask"
       TOURIST_ENV: "development"
       FLASK_RUN_HOST: "0.0.0.0"
       # The default port, 5000, conflicts with an MacOS service so listen to 5001 instead. See
       # https://twissmueller.medium.com/resolving-the-problem-of-port-5000-already-being-in-use-dd2fe4bad0be
       FLASK_RUN_PORT: "5001"
       FLASK_APP: "tourist"
+      DATA_DIR:
+      LOG_DIR:
     ports:
       - "5001:5001"
 
@@ -19,6 +21,8 @@ services:
 #    volumes:
 #      - ./dev-data:/data
 #      - ./tourist:/app/tourist
+#      # For debugging devcontainer workspace when running locally
+#      - .../tourist-with-flask:/workspace/tourist-with-flask
 
 # Add prefectagentdev when I've worked out how to have it share data with the flaskdebugrun
 #  prefectagentdev:

--- a/.devcontainer/setup-dev-data.sh
+++ b/.devcontainer/setup-dev-data.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 mkdir dev-data
 mkdir logs
 


### PR DESCRIPTION
Fixed file mode and added #! line. Tested by running with `docker compose -f .devcontainer/compose.yaml run flaskdebugrun ./.devcontainer/setup-dev-data.sh`