### PR TITLE
fix setup-dev-data.sh

### DIFF
--- a/.devcontainer/setup-dev-data.sh
+++ b/.devcontainer/setup-dev-data.sh
@@ -5,4 +5,4 @@ mkdir logs
 cp tourist/tests/spatial_metadata.sqlite dev-data/tourist.db
 
 # Import JSON lines file. Get from old system or in the test directory.
-FLASK_APP=tourist flask sync import_jsonl tourist/tests/testentities.jsonl
+FLASK_APP=tourist TOURIST_ENV=development flask --debug sync import_jsonl tourist/tests/testentities.jsonl

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,6 @@ RUN chmod --recursive a+r /app
 # RUN apt-get purge --yes gcc && apt-get autoremove --yes && apt-get clean autoclean
 
 ENV FLASK_APP=tourist
-ENV DATA_DIR=/data
-ENV LOG_DIR=/data
 
 # Entry CMD is set by the compose.yaml service command.
 


### PR DESCRIPTION
flask in setup-dev-data.sh was accessing the production path /data instead of development.