### PR TITLE
add small prod container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 # Inspired by https://blog.logrocket.com/build-deploy-flask-app-using-docker/ and https://medium.com/swlh/flask-docker-the-basics-66a699aa1e7d
 
-
 # start by pulling the python image
 FROM python:3.10.7-buster AS builder
 
 # Install git because some packages in requirements need it.
 RUN apt-get update && apt-get install --yes git gcc libsqlite3-mod-spatialite
-
 
 COPY requirements.txt uwsgi.ini /app/
 # install the dependencies and packages in the requirements file.
@@ -14,38 +12,31 @@ COPY requirements.txt uwsgi.ini /app/
 # has, released in 2019 and doesn't support the 'module' ini directive).
 RUN pip install -r /app/requirements.txt uwsgi
 
-
 # Copy tourist source separately from other other files because it changes more often. This
-# increases the chances of the cached pip layer being used.
+# increases the chances of the cached layer created by `RUN pip` being used.
 COPY tourist /app/tourist
 RUN chmod --recursive a+r /app
 
-# Save some space by removing gcc and the apt cache
-# Disabled while making a devcontainer.
-# RUN apt-get purge --yes gcc && apt-get autoremove --yes && apt-get clean autoclean
+ENV FLASK_APP=tourist
+ENV TOURIST_ENV=development
+
+
+
+FROM python:3.10.7-slim-buster AS production
+
+# Inspecting the docker layers created above with wagoodman/dive shows the output from them
+# needed for running production is
+COPY --from=builder /app /app
+COPY --from=builder /usr/local /usr/local
+
+# Copying all the libs from builder is tricky because spatialite has quite a few transitive
+# dependencies, Dockerfile COPY copies symlink targets instead of the symlink (which
+# causes a ldconfig warning) and load_extension('.../mod_spatialite.so') in create_app tries to load
+# '.../mod_spatialite.so.so' for a reason I couldn't work out. So instead of COPY --from=builder ...
+# this uses apt-get to install libsqlite3-mod-spatialite, which works reliably.
+RUN apt-get update && apt-get install --yes libsqlite3-mod-spatialite && apt-get clean autoclean \
+    && rm -fr /var/lib/apt/lists \
 
 ENV FLASK_APP=tourist
+ENV TOURIST_ENV=production
 
-# Entry CMD is set by the compose.yaml service command.
-
-
-# The following would make a nice slim production image but the app fails to load due to:
-# File "/app/tourist/__init__.py", line 87, in load_spatialite
-#   dbapi_conn.load_extension('/usr/lib/x86_64-linux-gnu/mod_spatialite.so')
-# sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) /usr/lib/x86_64-linux-gnu/mod_spatialite.so.so: cannot open shared object file: No such file or di
-#
-# I'm guessing this is something to do with ldconfig not updating /etc correctly because the
-# /usr/lib paths are the same as the build image above.
-
-# FROM python:3.10.7-slim-buster AS production
-#
-# # Inspecting the docker layers created above with wagoodman/dive shows the output from them
-# # needed for running production is
-# COPY --from=builder /app /app
-# COPY --from=builder /usr/local /usr/local
-# COPY --from=builder /usr/lib/x86_64-linux-gnu/libfreexl.so* /usr/local/x86_64-linux-gnu/
-# COPY --from=builder /usr/lib/x86_64-linux-gnu/libgeos* /usr/local/x86_64-linux-gnu/
-# COPY --from=builder /usr/lib/x86_64-linux-gnu/libproj.so* /usr/local/x86_64-linux-gnu/
-# COPY --from=builder /usr/lib/x86_64-linux-gnu/mod_spatialite.so* /usr/local/x86_64-linux-gnu/
-# COPY --from=builder /usr/share/proj /usr/share/proj
-# RUN ldconfig

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,10 +1,8 @@
 services:
   uwsgi:
     build: .
-    image: tomgobravo/tourist-with-flask:tourist-docker
+    image: tomgobravo/tourist-production:latest
     command: uwsgi --strict --need-app --ini /app/uwsgi.ini
-    environment:
-      TOURIST_ENV: "production"
     volumes:
       - /var/local/www-data:/data
       - ./tourist/secrets.cfg:/app/tourist/secrets.cfg
@@ -24,7 +22,7 @@ services:
     restart: unless-stopped
   prefectagentproduction:
     build: .
-    image: tomgobravo/tourist-with-flask:tourist-docker
+    image: tomgobravo/tourist-production:latest
     command: prefect agent start -q production
     environment:
       PREFECT_HOME: "/prefect_home"


### PR DESCRIPTION
* defines production container starting with slim-buster and adding only what is needed to run production
* Set env TOURIST_ENV in Dockerfile making it easier to use codespace 