### PR TITLE
Upgrade flask and more

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,13 +34,14 @@ attrs==21.4.0
     #   -r requirements.in
     #   aiohttp
     #   cattrs
-    #   pytest
 beautifulsoup4==4.10.0
     # via
     #   -r requirements.in
     #   markdownify
-blinker==1.4
-    # via -r requirements.in
+blinker==1.6.2
+    # via
+    #   -r requirements.in
+    #   flask
 cachetools==5.2.0
     # via google-auth
 cattrs==22.2.0
@@ -78,10 +79,12 @@ cryptography==40.0.2
 docker==5.0.3
     # via prefect
 exceptiongroup==1.0.0rc9
-    # via cattrs
+    # via
+    #   cattrs
+    #   pytest
 fastapi==0.95.1
     # via prefect
-flask==2.2.3
+flask==2.3.2
     # via
     #   -r requirements.in
     #   flask-admin
@@ -107,7 +110,7 @@ flask-sqlalchemy==3.0.3
     # via
     #   -r requirements.in
     #   flask-migrate
-flask-wtf==1.0.0
+flask-wtf==1.1.1
     # via -r requirements.in
 freezegun==1.1.0
     # via -r requirements.in
@@ -149,11 +152,11 @@ idna==2.8
     #   yarl
 iniconfig==1.1.1
     # via pytest
-itsdangerous==2.0.1
+itsdangerous==2.1.2
     # via
     #   flask
     #   flask-wtf
-jinja2==3.0.3
+jinja2==3.1.2
     # via flask
 jsonpatch==1.32
     # via prefect
@@ -208,8 +211,6 @@ prefect==2.4.1
     # via -r requirements.in
 psycopg2-binary==2.9.3
     # via -r requirements.in
-py==1.11.0
-    # via pytest
 pyasn1==0.4.8
     # via
     #   pyasn1-modules
@@ -226,7 +227,7 @@ pygments==2.12.0
     # via rich
 pyparsing==3.0.6
     # via packaging
-pytest==7.1.3
+pytest==7.3.1
     # via
     #   -r requirements.in
     #   pytest-mock
@@ -341,7 +342,7 @@ websocket-client==1.3.3
     # via
     #   docker
     #   kubernetes
-werkzeug==2.2.3
+werkzeug==2.3.3
     # via
     #   flask
     #   flask-dance

--- a/tourist/tests/conftest.py
+++ b/tourist/tests/conftest.py
@@ -1,4 +1,3 @@
-import flask_wtf
 import pytest
 from flask_login import FlaskLoginClient
 from tourist import create_app
@@ -27,64 +26,6 @@ def path_relative(rel: str) -> str:
     return os.path.join(this_dir, rel)
 
 
-# https://gist.github.com/singingwolfboy/2fca1de64950d5dfed72
-import flask
-from flask_wtf.csrf import generate_csrf
-# Flask's assumptions about an incoming request don't quite match up with
-# what the test client provides in terms of manipulating cookies, and the
-# CSRF system depends on cookies working correctly. This little class is a
-# fake request that forwards along requests to the test client for setting
-# cookies.
-class RequestShim(object):
-    """
-    A fake request that proxies cookie-related methods to a Flask test client.
-    """
-    def __init__(self, client):
-        self.client = client
-        self.vary = set({})
-
-    def set_cookie(self, key, value='', *args, **kwargs):
-        "Set the cookie on the Flask test client."
-        server_name = flask.current_app.config["SERVER_NAME"] or "localhost"
-        return self.client.set_cookie(
-            server_name, key=key, value=value, *args, **kwargs
-        )
-
-    def delete_cookie(self, key, *args, **kwargs):
-        "Delete the cookie on the Flask test client."
-        server_name = flask.current_app.config["SERVER_NAME"] or "localhost"
-        return self.client.delete_cookie(
-            server_name, key=key, *args, **kwargs
-        )
-
-
-# We're going to extend Flask's built-in test client class, so that it knows
-# how to look up CSRF tokens for you!
-class FlaskClient(FlaskLoginClient):
-    @property
-    def csrf_token(self):
-        # First, we'll wrap our request shim around the test client, so that
-        # it will work correctly when Flask asks it to set a cookie.
-        request = RequestShim(self)
-        # Next, we need to look up any cookies that might already exist on
-        # this test client, such as the secure cookie that powers `flask.session`,
-        # and make a test request context that has those cookies in it.
-        environ_overrides = {}
-        self.cookie_jar.inject_wsgi(environ_overrides)
-        with self.application.test_request_context(
-                "/login", environ_overrides=environ_overrides,
-            ):
-            # Now, we call Flask-WTF's method of generating a CSRF token...
-            csrf_token = generate_csrf()
-            # ...which also sets a value in `flask.session`, so we need to
-            # ask Flask to save that value to the cookie jar in the test
-            # client. This is where we actually use that request shim we made!
-            self.application.session_interface.save_session(flask.current_app, flask.session,
-                                                             request)
-            # And finally, return that CSRF token we got from Flask-WTF.
-            return csrf_token
-
-
 @pytest.fixture
 def test_app(tmp_path):
     config = tourist.config.make_test_config(tmp_path)
@@ -92,5 +33,5 @@ def test_app(tmp_path):
     shutil.copy(src=path_relative('spatial_metadata.sqlite'), dst=config.SQLITE_DB_PATH)
     app = create_app(config)
     # FlaskLoginClient adds support for test_client(user=user)
-    app.test_client_class = FlaskClient
+    app.test_client_class = FlaskLoginClient
     yield app


### PR DESCRIPTION
- Upgrade flask and more. Replace undocumented complicated csrf_token access with flask.g.csrf_token

Dependencies updated with
```
pip-compile --upgrade-package flask-pagedown --upgrade-package flask-login --upgrade-package flask_dance --upgrade-package
pip-compile --upgrade-package flask-pagedown --upgrade-package flask-login --upgrade-package flask_dance
```
then manually removed `py`, which pytest doesn't need any longer.

Tested with:
```
pip-sync
python -m pytest tourist/tests/
```

