### PR TITLE
add config._WorkspaceConfig

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -4,28 +4,19 @@
 services:
   flaskdebugrun:
     image: tomgobravo/tourist-builder:latest
-    working_dir: /workspace/tourist-with-flask
+    working_dir: /workspaces/tourist-with-flask
     command: flask --debug run
     environment:
-      PYTHONPATH: "/workspace/tourist-with-flask"
-      TOURIST_ENV: "development"
       FLASK_RUN_HOST: "0.0.0.0"
       # The default port, 5000, conflicts with an MacOS service so listen to 5001 instead. See
       # https://twissmueller.medium.com/resolving-the-problem-of-port-5000-already-being-in-use-dd2fe4bad0be
       FLASK_RUN_PORT: "5001"
-      FLASK_APP: "tourist"
-      DATA_DIR:
-      LOG_DIR:
     ports:
       - "5001:5001"
-
-# volumes: commented out because the source and data come from somewhere else in the devcontainer
-# setup
-#    volumes:
-#      - ./dev-data:/data
-#      - ./tourist:/app/tourist
-#      # For debugging devcontainer workspace when running locally
-#      - .../tourist-with-flask:/workspace/tourist-with-flask
+    volumes:
+      # Mount the parent directory at the same path as github codespaces. When
+      # TOURIST_ENV=workspace config.py uses this for the data and logs.
+      - ../.:/workspaces/tourist-with-flask
 
 # Add prefectagentdev when I've worked out how to have it share data with the flaskdebugrun
 #  prefectagentdev:

--- a/.devcontainer/setup-dev-data.sh
+++ b/.devcontainer/setup-dev-data.sh
@@ -7,4 +7,4 @@ mkdir logs
 cp tourist/tests/spatial_metadata.sqlite dev-data/tourist.db
 
 # Import JSON lines file. Get from old system or in the test directory.
-FLASK_APP=tourist TOURIST_ENV=development flask --debug sync import_jsonl tourist/tests/testentities.jsonl
+flask --debug sync import_jsonl tourist/tests/testentities.jsonl

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ FROM python:3.10.7-buster AS builder
 # From https://docs.github.com/en/enterprise-server@3.8/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images
 LABEL org.opencontainers.image.source=https://github.com/TomGoBravo/tourist-with-flask
 
+# Put ENV at the top; it seems to be ignored when it is the last statement.
+ENV FLASK_APP=tourist TOURIST_ENV=workspace
+
 # Install git because some packages in requirements need it.
 RUN apt-get update && apt-get install --yes git gcc libsqlite3-mod-spatialite
 
@@ -21,8 +24,6 @@ RUN pip install -r /app/requirements.txt uwsgi
 COPY tourist /app/tourist
 RUN chmod --recursive a+r /app
 
-ENV FLASK_APP=tourist
-ENV TOURIST_ENV=development
 
 
 
@@ -30,6 +31,9 @@ FROM python:3.10.7-slim-buster AS production
 
 # From https://docs.github.com/en/enterprise-server@3.8/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images
 LABEL org.opencontainers.image.source=https://github.com/TomGoBravo/tourist-with-flask
+
+# Put ENV at the top; it seems to be ignored when it is the last statement.
+ENV FLASK_APP=tourist TOURIST_ENV=production
 
 # Inspecting the docker layers created above with wagoodman/dive shows the output from them
 # needed for running production is
@@ -43,7 +47,3 @@ COPY --from=builder /usr/local /usr/local
 # this uses apt-get to install libsqlite3-mod-spatialite, which works reliably.
 RUN apt-get update && apt-get install --yes libsqlite3-mod-spatialite && apt-get clean autoclean \
     && rm -fr /var/lib/apt/lists \
-
-ENV FLASK_APP=tourist
-ENV TOURIST_ENV=production
-

--- a/tourist/tests/test_config.py
+++ b/tourist/tests/test_config.py
@@ -13,8 +13,8 @@ def test_production(monkeypatch):
     assert not app.config["TESTING"]
 
 
-def test_development(monkeypatch):
-    monkeypatch.setenv("TOURIST_ENV", "development")
+def test_flask_debug_true_local(monkeypatch):
+    monkeypatch.delenv("TOURIST_ENV", raising=False)
     app = flask.Flask('testflask')
     app.config.from_object(tourist.config.by_env(flask_debug=True))
 
@@ -22,3 +22,14 @@ def test_development(monkeypatch):
     assert 'www-data' not in app.config["LOG_DIR"]
     assert app.config["SECRET_KEY"] == '87294798798799'
     assert app.config["TESTING"]
+    assert app.config["SQLALCHEMY_DATABASE_URI"].endswith("/dev-data/tourist.db")
+
+
+def test_workspace(monkeypatch):
+    monkeypatch.setenv("TOURIST_ENV", "workspace")
+    app = flask.Flask('testflask')
+    app.config.from_object(tourist.config.by_env(flask_debug=True))
+
+    assert app.config["SQLALCHEMY_DATABASE_URI"] == \
+           "sqlite:////workspaces/tourist-with-flask/dev-data/tourist.db"
+    assert app.config["LOG_DIR"]  == "/workspaces/tourist-with-flask/logs"


### PR DESCRIPTION
add `config._WorkspaceConfig` with absolute paths to logs and data files. prefect agent copies the project, including data, to a tmpdir which prevents a dev agent modifying the flask data.
This change modifies config.py. I'll make sure it works in production before making another change to get the dev agent working.