### PR TITLE
use specific sqlalchemy-continuum commit to fix warnings

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,10 @@ attrs
 cattrs
 git+https://github.com/TomGoBravo/flask-admin@leaflet-control-geocoder-geoatileattributionurl#egg=Flask-Admin
 geojson>=2.4.1
-SQLAlchemy-Continuum
+
+# Use head as of 2023-08-27 to get fix for https://github.com/kvesteri/sqlalchemy-continuum/issues/322 because it
+# hasn't been released yet.
+SQLAlchemy-Continuum @ git+https://github.com/kvesteri/sqlalchemy-continuum@a7a6bd7952185b1f82af985c0271834d886a617c
 Flask
 Flask-SQLAlchemy
 Flask-Markdown

--- a/requirements.txt
+++ b/requirements.txt
@@ -306,7 +306,7 @@ sqlalchemy[asyncio]==1.4.31
     #   prefect
     #   sqlalchemy-continuum
     #   sqlalchemy-utils
-sqlalchemy-continuum==1.4.0
+sqlalchemy-continuum @ git+https://github.com/kvesteri/sqlalchemy-continuum@a7a6bd7952185b1f82af985c0271834d886a617c
     # via -r requirements.in
 sqlalchemy-utils==0.38.2
     # via sqlalchemy-continuum


### PR DESCRIPTION
Use head as of now to get fix for https://github.com/kvesteri/sqlalchemy-continuum/issues/322 because it hasn't been released yet. This fixes some warnings that were output when running `PYTHONPATH=. pytest tourist/tests/`