### PR TITLE
update flask-admin to recent branch

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,8 @@
 
 attrs
 cattrs
-git+https://github.com/TomGoBravo/flask-admin@leaflet-control-geocoder-geoatileattributionurl#egg=Flask-Admin
+# Using a branch with my work-around until https://github.com/flask-admin/flask-admin/issues/2351 is fixed.
+flask-admin @ git+https://github.com/TomGoBravo/flask-admin@bab9d1b8c87f70296af51230645ee8ece09ca9e0
 geojson>=2.4.1
 
 # Use head as of 2023-08-27 to get fix for https://github.com/kvesteri/sqlalchemy-continuum/issues/322 because it

--- a/requirements.txt
+++ b/requirements.txt
@@ -94,7 +94,7 @@ flask==2.3.2
     #   flask-pagedown
     #   flask-sqlalchemy
     #   flask-wtf
-flask-admin @ git+https://github.com/TomGoBravo/flask-admin@leaflet-control-geocoder-geoatileattributionurl
+flask-admin @ git+https://github.com/TomGoBravo/flask-admin@bab9d1b8c87f70296af51230645ee8ece09ca9e0
     # via -r requirements.in
 flask-dance==6.2.0
     # via -r requirements.in


### PR DESCRIPTION
Update flask-admin to a branch that is only one commit away from the public head. The extra commit is needed as a work-around for https://github.com/flask-admin/flask-admin/issues/2351

The update fixes
```
tourist/tests/test_basic.py::test_heavy
  /home/thecap/.pyenv/versions/tourist-3.10.7/lib/python3.10/site-packages/flask_admin/form/widgets.py:2: DeprecationWarning: '_request_ctx_stack' is deprecated and will be removed in Flask 2.4.
    from flask.globals import _request_ctx_stack
```
thanks to https://github.com/flask-admin/flask-admin/pull/2286.